### PR TITLE
fix: Fixed URL for assignment checkout by request

### DIFF
--- a/src/api/assignments.ts
+++ b/src/api/assignments.ts
@@ -66,7 +66,7 @@ export const checkOutAssetByRequest = async (
   const response = await runFetch(
     `${
       import.meta.env.VITE_BACKEND_URL
-    }/api/assignments/check-in/${request_id}/`,
+    }/api/assignments/check-out/${request_id}/`,
     {
       method: 'POST',
       headers: {


### PR DESCRIPTION
It used to be check-in but is not correctly set to check-out